### PR TITLE
Updates required by current PhotoStation, added video thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,64 @@
 # Thumbnail Generator for Synology PhotoStation
-Creating thumbnails on the consumer level DiskStation NAS boxes by Synology is incredibly slow which makes indexing of large photo collections take forever to complete. It's much, much faster (days -> hours) to generate the thumbnails on your desktop computer over e.g. SMB using this small Python script.
+
+Creating thumbnails on the consumer level DiskStation NAS boxes by Synology is incredibly slow which makes indexing of large photo collections take forever to complete. It's much, much faster (days -> hours) to generate the thumbnails on your desktop computer over e.g. SMB using this small Python script. Alternatively, create the thumbnails locally on your desktop or laptop computer before before transferring images and thumbnails to the Synology DiskStation, for example with `rsync`. Thanks to user **tsohr**, creating thumbnails for videos is now supported as well.
 
 ## Usage
-`python dsthumbgen.py --directory <path>`
 
-Example: `python dsthumbgen.py --directory c:\photos`
+`python psthumbgen.py --directory <path>`
 
-Subdirectories will always be processed.
+Example: `python psthumbgen.py --directory photos`
+
+Subdirectories will always be processed. The example above assumes that you are in a directory containing the `photos` subdirectory with your images. You can, of course, also specify an absolute path name.
+
+## Command line options:
+
+`--directory <path>` or `-d <path>` - the directory with your image library
+
+`-eaDir` or `-e` - write directly to the `@eaDir` directory instead of `eaDir_tmp`, works on MacOS and Linux, but not on Windows
+
+`--force` or `-f` - force regeneration of all thumbnails even if they already exist
+
 
 ## Requirements
-The script needs the Pillow imaing library (https://pypi.python.org/pypi/Pillow/2.5.1) to be installed.
+
+The script needs the Pillow imaing library (https://pypi.python.org/pypi/Pillow) to be installed:
+
+```sh
+pip install Pillow
+```
+
+`ffmpeg` is required for creating thumbnails for videos. See https://www.ffmpeg.org/download.html for installation instructions. On MacOS, you can also use homebrew (`brew install ffmpeg`).
 
 ## Good to know
+
 Given a file and folder structure like below:
 
 ```
-c:\photos\001.jpg
-c:\photos\dir1\002.jpg
+photos\001.jpg
+photos\dir1\002.jpg
 ```
 
 ...the utility will create the following:
 
 ```
-c:\photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_XL.jpg
-c:\photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_B.jpg
-c:\photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_M.jpg
-c:\photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_PREVIEW.jpg
-c:\photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_S.jpg
-c:\photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_XL.jpg
-c:\photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_B.jpg
-c:\photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_M.jpg
-c:\photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_PREVIEW.jpg
-c:\photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_S.jpg
+photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_XL.jpg
+photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_B.jpg
+photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_M.jpg
+photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_SM.jpg
+photos\eaDir_tmp\001.jpg\SYNOPHOTO_THUMB_S.jpg
+photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_XL.jpg
+photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_B.jpg
+photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_M.jpg
+photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_SM.jpg
+photos\dir1\eaDir_tmp\002.jpg\SYNOPHOTO_THUMB_S.jpg
 ```
 
-`eaDir_tmp` is used as a temporary directory name as @ characters are not valid in file names on Windows. Therefore these folders must be renamed to `@eaDir` for PhotoStation to recognize them. This renaming process must be done via SSH to the DiskStation unless the volume is mounted by NFS. Useful commands:
+**On Windows systems:** `eaDir_tmp` is used as a temporary directory name as @ characters are not valid in file names on Windows. Therefore these folders must be renamed to `@eaDir` for PhotoStation to recognize them. This renaming process must be done via SSH to the DiskStation unless the volume is mounted by NFS.
+
+**On MacOS or Linux systems:** You can write directly to `@eaDir`, use the `-e` or `--eaDir` command line option for this.
+
+
+Useful commands:
 
 ```
 # remove any existing thumbnail directories, dry-run check print out before running next command!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Thumbnail Generator for Synology PhotoStation
 
-Creating thumbnails on the consumer level DiskStation NAS boxes by Synology is incredibly slow which makes indexing of large photo collections take forever to complete. It's much, much faster (days -> hours) to generate the thumbnails on your desktop computer over e.g. SMB using this small Python script. Alternatively, create the thumbnails locally on your desktop or laptop computer before before transferring images and thumbnails to the Synology DiskStation, for example with `rsync`. Thanks to user **tsohr**, creating thumbnails for videos is now supported as well.
+Creating thumbnails on the consumer level DiskStation NAS boxes by Synology is incredibly slow which makes indexing of large photo collections take forever to complete. It's much, much faster (days -> hours) to generate the thumbnails on your desktop computer over e.g. SMB using this small Python script. Alternatively, create the thumbnails locally on your desktop or laptop computer before before transferring images and thumbnails to the Synology DiskStation, for example with `rsync`.
+
+Thanks to user **tsohr**, creating thumbnails for videos is now supported as well, although it might need further enhancements - while the tool generates thumbnails for the original video files, Synology often creates an additional converted video format in `@eaDir` and also thumbnails for this converted video format. Further investigation is needed to understand when such converted videos are created and which output video format is used for which video format of the original file.
 
 ## Usage
 

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -206,7 +206,7 @@ def create_thumbnails(source_path, dest_dir):
                 continue
 
         try:
-            im.thumbnail((sys.maxsize, thumb[1]), Image.ANTIALIAS)
+            im.thumbnail((sys.maxsize, thumb[1]), Image.LANCZOS)
             im.save(os.path.join(dest_dir, thumb[0]))
         except Exception as e:
             print(e)

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -1,18 +1,16 @@
-import sys
-import os
-import re
 import argparse
 import errno
+import os
+import re
+import subprocess
+import sys
+import tempfile
 import time
-from PIL import Image
+from multiprocessing import Pool, Value
+
+from PIL import Image, ImageOps
 
 Image.MAX_IMAGE_PIXELS = None
-from multiprocessing import Pool
-from multiprocessing import Value
-import subprocess
-import tempfile
-from PIL import ImageOps
-from PIL.ExifTags import TAGS
 
 
 class State(object):
@@ -194,7 +192,6 @@ def create_thumbnails(source_path, dest_dir):
         return
 
     try:
-        exif = im._getexif()
         image = ImageOps.exif_transpose(im)
         im = image
     except Exception as e:
@@ -216,4 +213,5 @@ def create_thumbnails(source_path, dest_dir):
 
 
 if __name__ == "__main__":
+    sys.exit(main())
     sys.exit(main())

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -5,6 +5,7 @@ import argparse
 import errno
 import time
 from PIL import Image
+
 Image.MAX_IMAGE_PIXELS = None
 from multiprocessing import Pool
 from multiprocessing import Value
@@ -13,10 +14,11 @@ import tempfile
 from PIL import ImageOps
 from PIL.ExifTags import TAGS
 
+
 class State(object):
     def __init__(self):
-        self.counter = Value('i', 0)
-        self.start_ticks = Value('d', time.process_time())
+        self.counter = Value("i", 0)
+        self.start_ticks = Value("d", time.process_time())
 
     def increment(self, n=1):
         with self.counter.get_lock():
@@ -56,29 +58,47 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Create thumbnails for Synology Photo Station.")
-    parser.add_argument('-d', "--directory", required=True,
-                        help="Directory to generate thumbnails for. "
-                             "Subdirectories will always be processed.")
-    parser.add_argument("-e", "--eaDir", required=False, default=False, action="store_true",
-                        help="write directly to @eaDir rather than eaDir_tmp")
-    parser.add_argument("-f", "--force", required=False, default=False, action="store_true",
-                        help="force regeneration of all thumbnails.")
+        description="Create thumbnails for Synology Photo Station."
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        required=True,
+        help="Directory to generate thumbnails for. "
+        "Subdirectories will always be processed.",
+    )
+    parser.add_argument(
+        "-e",
+        "--eaDir",
+        required=False,
+        default=False,
+        action="store_true",
+        help="write directly to @eaDir rather than eaDir_tmp",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        required=False,
+        default=False,
+        action="store_true",
+        help="force regeneration of all thumbnails.",
+    )
 
     return parser.parse_args()
 
 
 def find_files(dir):
-    valid_exts = ('jpeg', 'jpg', 'bmp', 'gif', 'png', 'avi', 'mp4', 'mov', 'm4v')
-    valid_exts_re = "|".join(
-        map((lambda ext: ".*\\.{0}$".format(ext)), valid_exts))
+    valid_exts = ("jpeg", "jpg", "bmp", "gif", "png", "avi", "mp4", "mov", "m4v")
+    valid_exts_re = "|".join(map((lambda ext: ".*\\.{0}$".format(ext)), valid_exts))
 
     for root, dirs, files in os.walk(dir):
         for name in files:
-            if re.match(valid_exts_re, name, re.IGNORECASE) \
-                    and not root.endswith('@eaDir') \
-                    and not name.startswith('SYNOPHOTO_THUMB') \
-                    and not name.startswith('.'):
+            if (
+                re.match(valid_exts_re, name, re.IGNORECASE)
+                and not root.endswith("@eaDir")
+                and not name.startswith("SYNOPHOTO_THUMB")
+                and not name.startswith(".")
+            ):
                 yield os.path.join(root, name)
 
 
@@ -87,9 +107,11 @@ def print_progress():
     state.increment(1)
     processed = state.value
     if processed % 10 == 0:
-        print("{0} files processed so far, averaging {1:.2f} files per second."
-              .format(processed, float(processed) /
-                                 (float(time.process_time() - state.start))))
+        print(
+            "{0} files processed so far, averaging {1:.2f} files per second.".format(
+                processed, float(processed) / (float(time.process_time() - state.start))
+            )
+        )
 
 
 def process_file(file_path):
@@ -97,11 +119,11 @@ def process_file(file_path):
     print(file_path)
 
     (dir, filename) = os.path.split(file_path)
-    
-    if (state.eaDir):
-        thumb_dir = os.path.join(dir, '@eaDir', filename)
+
+    if state.eaDir:
+        thumb_dir = os.path.join(dir, "@eaDir", filename)
     else:
-        thumb_dir = os.path.join(dir, 'eaDir_tmp', filename)
+        thumb_dir = os.path.join(dir, "eaDir_tmp", filename)
     ensure_directory_exists(thumb_dir)
 
     create_thumbnails(file_path, thumb_dir)
@@ -119,11 +141,13 @@ def ensure_directory_exists(path):
 
 def create_thumbnails(source_path, dest_dir):
     global state
-    to_generate = (('SYNOPHOTO_THUMB_XL.jpg', 1280),
-                   ('SYNOPHOTO_THUMB_B.jpg', 480),
-                   ('SYNOPHOTO_THUMB_M.jpg', 320),
-                   ('SYNOPHOTO_THUMB_SM.jpg', 240),
-                   ('SYNOPHOTO_THUMB_S.jpg', 90))
+    to_generate = (
+        ("SYNOPHOTO_THUMB_XL.jpg", 1280),
+        ("SYNOPHOTO_THUMB_B.jpg", 480),
+        ("SYNOPHOTO_THUMB_M.jpg", 320),
+        ("SYNOPHOTO_THUMB_SM.jpg", 240),
+        ("SYNOPHOTO_THUMB_S.jpg", 90),
+    )
 
     skip_this = True
     if state.force:
@@ -140,14 +164,28 @@ def create_thumbnails(source_path, dest_dir):
         return
 
     spath_low = source_path.lower()
-    video_ext = ('avi', 'mp4', 'mov', 'm4v') 
+    video_ext = ("avi", "mp4", "mov", "m4v")
     snapshot_file = False
 
     try:
-        if (spath_low.endswith(video_ext)):
+        if spath_low.endswith(video_ext):
             temp_name = next(tempfile._get_candidate_names())
-            snapshot_file=os.path.join(dest_dir, temp_name + ".jpg")
-            subprocess.call(['ffmpeg', '-hide_banner', '-loglevel', 'error', '-i', source_path, '-ss', '00:00:00.000', '-vframes', '1', snapshot_file])
+            snapshot_file = os.path.join(dest_dir, temp_name + ".jpg")
+            subprocess.call(
+                [
+                    "ffmpeg",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-i",
+                    source_path,
+                    "-ss",
+                    "00:00:00.000",
+                    "-vframes",
+                    "1",
+                    snapshot_file,
+                ]
+            )
             im = Image.open(snapshot_file)
         else:
             im = Image.open(source_path)
@@ -161,8 +199,6 @@ def create_thumbnails(source_path, dest_dir):
         im = image
     except Exception as e:
         print(e)
-
-
 
     for thumb in to_generate:
         if not state.force:

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -157,7 +157,7 @@ def create_thumbnails(source_path, dest_dir):
             if os.path.exists(os.path.join(dest_dir, thumb[0])):
                 continue
             else:
-                skip_all = False
+                skip_this = False
                 break
 
     if skip_this:

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -62,7 +62,8 @@ def parse_args():
                              "Subdirectories will always be processed.")
     parser.add_argument("-e", "--eaDir", required=False, default=False, action="store_true",
                         help="write directly to @eaDir rather than eaDir_tmp")
-    parser.add_argument("-f", "--force", required=False, default=False, action="store_true",)
+    parser.add_argument("-f", "--force", required=False, default=False, action="store_true",
+                        help="force regeneration of all thumbnails.")
 
     return parser.parse_args()
 

--- a/psthumbgen.py
+++ b/psthumbgen.py
@@ -7,7 +7,10 @@ import time
 from PIL import Image
 from multiprocessing import Pool
 from multiprocessing import Value
-
+import subprocess
+import tempfile
+from PIL import ImageOps
+from PIL.ExifTags import TAGS
 
 class State(object):
     def __init__(self):
@@ -27,9 +30,11 @@ class State(object):
         return self.start_ticks.value
 
 
-def init(args):
+def init(s, args):
     global state
-    state = args
+    state = s
+    state.eaDir = args.eaDir
+    state.force = args.force
 
 
 def main():
@@ -38,7 +43,11 @@ def main():
 
     files = find_files(args.directory)
 
-    with Pool(processes=4, initializer=init, initargs=(state, )) as pool:
+    cores = os.cpu_count()
+    half_cores = cores // 2
+    parallel = max(4, half_cores)
+
+    with Pool(processes=parallel, initializer=init, initargs=(state, args)) as pool:
         pool.map(process_file, files)
 
     print("{0} files processed in total.".format(state.value))
@@ -47,15 +56,18 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Create thumbnails for Synology Photo Station.")
-    parser.add_argument("--directory", required=True,
+    parser.add_argument('-d', "--directory", required=True,
                         help="Directory to generate thumbnails for. "
                              "Subdirectories will always be processed.")
+    parser.add_argument("-e", "--eaDir", required=False, default=False, action="store_true",
+                        help="write directly to @eaDir rather than eaDir_tmp")
+    parser.add_argument("-f", "--force", required=False, default=False, action="store_true",)
 
     return parser.parse_args()
 
 
 def find_files(dir):
-    valid_exts = ('jpeg', 'jpg', 'bmp', 'gif')
+    valid_exts = ('jpeg', 'jpg', 'bmp', 'gif', 'png', 'avi', 'mp4', 'mov', 'm4v')
     valid_exts_re = "|".join(
         map((lambda ext: ".*\\.{0}$".format(ext)), valid_exts))
 
@@ -77,10 +89,15 @@ def print_progress():
 
 
 def process_file(file_path):
+    global state
     print(file_path)
 
     (dir, filename) = os.path.split(file_path)
-    thumb_dir = os.path.join(dir, 'eaDir_tmp', filename)
+    
+    if (state.eaDir):
+        thumb_dir = os.path.join(dir, '@eaDir', filename)
+    else:
+        thumb_dir = os.path.join(dir, 'eaDir_tmp', filename)
     ensure_directory_exists(thumb_dir)
 
     create_thumbnails(file_path, thumb_dir)
@@ -97,20 +114,65 @@ def ensure_directory_exists(path):
 
 
 def create_thumbnails(source_path, dest_dir):
-    im = Image.open(source_path)
-
+    global state
     to_generate = (('SYNOPHOTO_THUMB_XL.jpg', 1280),
                    ('SYNOPHOTO_THUMB_B.jpg', 640),
                    ('SYNOPHOTO_THUMB_M.jpg', 320),
                    ('SYNOPHOTO_THUMB_PREVIEW.jpg', 160),
                    ('SYNOPHOTO_THUMB_S.jpg', 120))
 
-    for thumb in to_generate:
-        if os.path.exists(os.path.join(dest_dir, thumb[0])):
-            continue
+    skip_this = True
+    if state.force:
+        skip_this = False
+    else:
+        for thumb in to_generate:
+            if os.path.exists(os.path.join(dest_dir, thumb[0])):
+                continue
+            else:
+                skip_all = False
+                break
 
-        im.thumbnail((thumb[1], thumb[1]), Image.ANTIALIAS)
-        im.save(os.path.join(dest_dir, thumb[0]))
+    if skip_this:
+        return
+
+    spath_low = source_path.lower()
+    video_ext = ('avi', 'mp4', 'mov', 'm4v') 
+    snapshot_file = False
+
+    try:
+        if (spath_low.endswith(video_ext)):
+            temp_name = next(tempfile._get_candidate_names())
+            snapshot_file=os.path.join(dest_dir, temp_name + ".jpg")
+            subprocess.call(['ffmpeg', '-hide_banner', '-loglevel', 'error', '-i', source_path, '-ss', '00:00:00.000', '-vframes', '1', snapshot_file])
+            im = Image.open(snapshot_file)
+        else:
+            im = Image.open(source_path)
+    except Exception as e:
+        print(e)
+        return
+
+    try:
+        exif = im._getexif()
+        image = ImageOps.exif_transpose(im)
+        im = image
+    except Exception as e:
+        print(e)
+
+
+
+    for thumb in to_generate:
+        if not state.force:
+            if os.path.exists(os.path.join(dest_dir, thumb[0])):
+                continue
+
+        try:
+            im.thumbnail((thumb[1], thumb[1]), Image.ANTIALIAS)
+            im.save(os.path.join(dest_dir, thumb[0]))
+        except Exception as e:
+            print(e)
+
+    if snapshot_file:
+        os.remove(snapshot_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some improvements and fixes:

- Set `Image.MAX_IMAGE_PIXELS = None` because otherwise the script exits with an exception for large images, such as panoramic images.
- Do not process any files with names that start with a dot. Such files are created automatically by MacOS on some file systems, such as VAT/exFAT, they contain some metadata for their target files. Since these metadata files also had file extensions jpg etc. (although they do not contain image data but just metadata), previously they were processed by the script creating new `@eaDir` directories within `@eaDir` when re-running the script. This was an issue if the thumbnails are created on a source system with MacOS before being transferred to the Synology DiskStation.
- The script created thumbnails of dimensions that were different from those created by the Synology PhotoStation. Synology creates images for which the height is predefined and fixed, while the width is dynamic, that is, the width is the result of scaling the image to the target height while maintaining the aspect ratio. Previously, the script did not scale like that if the image width is larger than the image height.
- Synology PhotStation does not create a file `SYNOPHOTO_THUMB_PREVIEW.jpg`, but `SYNOPHOTO_THUMB_SM.jpg` instead.
- `Image.ANTIALIAS` does not exist in up-to-date `Pillow` versions, was replaced with `Image.LANCZOS`.
- Added most modifications from the pull request by @tsohr (video thumbnails, more command line parameters, use more threads if more than 8 cores are available); also fixed that pull request which failed to generate thumbnails for images.